### PR TITLE
Improve script_decomp.sh failure handling, among other things

### DIFF
--- a/scripts/script_decomp.sh
+++ b/scripts/script_decomp.sh
@@ -13,12 +13,29 @@ do
     file="$(basename "$file")"
     echo "$((100*$counter/$filecount))% - $file"
     python2 scripts/script_redirect.py script_nxs/$file > script/temp/$file.out # Decrypts into nxs
+    if [ $? -ne 0 ]
+    then
+        echo "Failed...sad face. Copied to 'script/failed/'"
+        cp "script_nxs/$file" "script/failed"
+        counter=$(($counter+1))
+        continue
+    fi
     python2 scripts/pyc_decryptor.py script/temp/$file.out script/pyc/$file.pyc # Demangles opcodes of nxs into pyc
+    if [ $? -ne 0 ]
+    then
+        echo "Failed...sad face. Copied to 'script/failed/'"
+        cp "script_nxs/$file" "script/failed"
+        counter=$(($counter+1))
+        continue
+    fi
     python3 scripts/decompile_pyc.py -o script/out/$file.py script/pyc/$file.pyc 2> /dev/null # Decompiles pyc into py
     if [ $? -ne 0 ]
     then 
-        echo "Failed...sad face. Copied to script/failed"
+        echo "Failed...sad face. Copied to 'script/failed/'"
         cp "script_nxs/$file" "script/failed"
+        counter=$(($counter+1))
+        continue
+
         # echo "Trying pycdc"
         # pycdc/pycdc script/pyc/$file.pyc > script/out/$file.py
         # if [ $? -ne 0 ]
@@ -37,5 +54,4 @@ do
         mkdir -p script/layout/$file_dir
         cp script/out/$file.py script/layout/$file_name
     fi
-    counter=$(($counter+1))
 done

--- a/scripts/script_decomp.sh
+++ b/scripts/script_decomp.sh
@@ -3,17 +3,22 @@
 mkdir -p script/temp
 mkdir -p script/pyc
 mkdir -p script/out
+mkdir -p script/failed
 
-for file in "script_nxs"/*.nxs
+filecount=$(ls -1 script_nxs | wc -l)
+counter=0
+
+for file in script_nxs/*
 do
     file="$(basename "$file")"
-    echo $file
-    python2 scripts/script_redirect.py script_nxs/$file > script/temp/$file.out
-    python2 scripts/pyc_decryptor.py script/temp/$file.out script/pyc/$file.pyc
-    python3 scripts/decompile_pyc.py -o script/out/$file.py script/pyc/$file.pyc 2> /dev/null
+    echo "$((100*$counter/$filecount))% - $file"
+    python2 scripts/script_redirect.py script_nxs/$file > script/temp/$file.out # Decrypts into nxs
+    python2 scripts/pyc_decryptor.py script/temp/$file.out script/pyc/$file.pyc # Demangles opcodes of nxs into pyc
+    python3 scripts/decompile_pyc.py -o script/out/$file.py script/pyc/$file.pyc 2> /dev/null # Decompiles pyc into py
     if [ $? -ne 0 ]
     then 
-        echo "Failed...sad face"
+        echo "Failed...sad face. Copied to script/failed"
+        cp "script_nxs/$file" "script/failed"
         # echo "Trying pycdc"
         # pycdc/pycdc script/pyc/$file.pyc > script/out/$file.py
         # if [ $? -ne 0 ]
@@ -32,4 +37,5 @@ do
         mkdir -p script/layout/$file_dir
         cp script/out/$file.py script/layout/$file_name
     fi
+    counter=$(($counter+1))
 done

--- a/scripts/script_decomp.sh
+++ b/scripts/script_decomp.sh
@@ -31,17 +31,22 @@ do
     python3 scripts/decompile_pyc.py -o script/out/$file.py script/pyc/$file.pyc 2> /dev/null # Decompiles pyc into py
     if [ $? -ne 0 ]
     then 
-        echo "Failed...sad face. Copied to 'script/failed/'"
-        cp "script_nxs/$file" "script/failed"
-        counter=$(($counter+1))
-        continue
+        # A lot of the time Python 2 works instead
+        python2 scripts/decompile_pyc.py -o script/out/$file.py script/pyc/$file.pyc 2> /dev/null # Decompiles pyc into py
+        if [ $? -ne 0 ]
+        then 
+            echo "Failed...sad face. Copied to 'script/failed/'"
+            cp "script_nxs/$file" "script/failed"
+            counter=$(($counter+1))
+            continue
 
-        # echo "Trying pycdc"
-        # pycdc/pycdc script/pyc/$file.pyc > script/out/$file.py
-        # if [ $? -ne 0 ]
-        # then
-        #     python3 tools/decompile_pyc.py -o script/out/$file.py script/pyc/$file.pyc 2> /dev/null
-        # fi
+            # echo "Trying pycdc"
+            # pycdc/pycdc script/pyc/$file.pyc > script/out/$file.py
+            # if [ $? -ne 0 ]
+            # then
+            #     python3 tools/decompile_pyc.py -o script/out/$file.py script/pyc/$file.pyc 2> /dev/null
+            # fi
+        fi
     fi
     file_name="$(head -n 5 script/out/$file.py | tail -n 1)"
     file_name=${file_name//\\/\/}
@@ -54,4 +59,5 @@ do
         mkdir -p script/layout/$file_dir
         cp script/out/$file.py script/layout/$file_name
     fi
+    counter=$(($counter+1))
 done


### PR DESCRIPTION
`script_decomp.sh` changes and context
- Improved failure handling: files that fail any stage of decompilation are copied from `script_nxs` to a `failed` folder.
- `npktool x script.npk` outputs a folder containing files packed within `script.npk`. These files may have non-NXS file extensions even if they may contain NXS-formatted data (encrypted/compressed NXS data to be accurate) and yet, `script_decomp.sh` only took the files with the NXS file extension resulting in data loss. I have changed the script to decompile all files in `script_nxs` instead of only the ones with the NXS file extension.
- Additionally, before this change, two files were not noticed. Once the `script.npk` is unpacked, there are two files that do not have NXS data inside of them. One is a list of all the NXS files in `script.npk` and their hierarchy (uncompressed/unencrypted) and the other is a PYC file (only the opcodes are mangled). The PYC file contains Python code for unpacking NPKs.
- Added a progress indicator.