### PR TITLE
Fix failure handling of script_decomp.sh

### DIFF
--- a/scripts/script_decomp.sh
+++ b/scripts/script_decomp.sh
@@ -3,7 +3,7 @@
 mkdir -p script/temp
 mkdir -p script/pyc
 mkdir -p script/out
-mkdir -p script/failed/
+mkdir -p script/failed
 
 filecount=$(ls -1 script_nxs | wc -l)
 counter=0

--- a/scripts/script_decomp.sh
+++ b/scripts/script_decomp.sh
@@ -3,7 +3,7 @@
 mkdir -p script/temp
 mkdir -p script/pyc
 mkdir -p script/out
-mkdir -p script/failed
+mkdir -p script/failed/
 
 filecount=$(ls -1 script_nxs | wc -l)
 counter=0
@@ -12,42 +12,23 @@ for file in script_nxs/*
 do
     file="$(basename "$file")"
     echo "$((100*$counter/$filecount))% - $file"
-    python2 scripts/script_redirect.py script_nxs/$file > script/temp/$file.out # Decrypts into nxs
-    if [ $? -ne 0 ]
-    then
-        echo "Failed...sad face. Copied to 'script/failed/'"
-        cp "script_nxs/$file" "script/failed"
-        counter=$(($counter+1))
-        continue
-    fi
-    python2 scripts/pyc_decryptor.py script/temp/$file.out script/pyc/$file.pyc # Demangles opcodes of nxs into pyc
-    if [ $? -ne 0 ]
-    then
-        echo "Failed...sad face. Copied to 'script/failed/'"
-        cp "script_nxs/$file" "script/failed"
-        counter=$(($counter+1))
-        continue
-    fi
-    python3 scripts/decompile_pyc.py -o script/out/$file.py script/pyc/$file.pyc 2> /dev/null # Decompiles pyc into py
-    if [ $? -ne 0 ]
-    then 
-        # A lot of the time Python 2 works instead
-        python2 scripts/decompile_pyc.py -o script/out/$file.py script/pyc/$file.pyc 2> /dev/null # Decompiles pyc into py
-        if [ $? -ne 0 ]
-        then 
-            echo "Failed...sad face. Copied to 'script/failed/'"
-            cp "script_nxs/$file" "script/failed"
-            counter=$(($counter+1))
-            continue
 
-            # echo "Trying pycdc"
-            # pycdc/pycdc script/pyc/$file.pyc > script/out/$file.py
-            # if [ $? -ne 0 ]
-            # then
-            #     python3 tools/decompile_pyc.py -o script/out/$file.py script/pyc/$file.pyc 2> /dev/null
-            # fi
-        fi
+    python2 scripts/script_redirect.py script_nxs/$file > script/temp/$file.out
+    python2 scripts/pyc_decryptor.py script/temp/$file.out script/pyc/$file.pyc
+    python3 scripts/decompile_pyc.py -o script/out/$file.py script/pyc/$file.pyc 2> /dev/null
+    if [ $? -ne 0 ]; then 
+        # A lot of the time Python 2 works instead
+        python2 scripts/decompile_pyc.py -o script/out/$file.py script/pyc/$file.pyc 2> /dev/null
+    
     fi
+
+    if [ ! -f script/out/$file.py ]; then
+        echo "Failed...sad face. Copied to 'script/failed/'"
+        cp "script_nxs/$file" "script/failed"
+        counter=$(($counter+1))
+        continue
+    fi
+
     file_name="$(head -n 5 script/out/$file.py | tail -n 1)"
     file_name=${file_name//\\/\/}
     regexp="# Embedded.*"


### PR DESCRIPTION
The script started failing before copying the Python script to the correct directory, even if there was valid Python to be copied.