### PR TITLE
Added support for global uncompyle6

### DIFF
--- a/scripts/decompile_pyc.py
+++ b/scripts/decompile_pyc.py
@@ -5,8 +5,15 @@ import sys
 import os
 dir_path = os.path.dirname(os.path.realpath(__file__))
 
-sys.path.insert(0, os.path.join(dir_path, "python-uncompyle6"))
+try:
+    import uncompyle6
+except ImportError as e:
+    sys.path.insert(0, os.path.join(dir_path, "python-uncompyle6"))
 
 from uncompyle6.bin.uncompile import main_bin
 
-main_bin("utf-8")
+try:
+    main_bin("utf-8")
+except TypeError:
+    # New version doesn't have the
+    main_bin()


### PR DESCRIPTION
The submodule version of uncompyle6 seems to be broken and fails when used by [eve-echoes-tools](https://github.com/xforce/eve-echoes-tools). The official package available via pip seems to be working.

Now before trying to use the submodule version of uncompyle, the script tries to import uncompyle6 directly. That way is it possible to install uncompyle via pip directly. Also fixed a problem with the main_bin command, as in the latest version of uncompyle, the "utf-8" parameter is deprecated.

If uncompyle6 is not installed, the script will still use the submodule so it does hopefully not affect other users of this repo.